### PR TITLE
Add linting and type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ">=3.10"
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          pip install .
+          pip install pylint
+
+      - name: pre-commit
+        uses: pre-commit/actions@v3.0.1
+
+      - name: pyright
+        uses: jakebailey/pyright-action@v2
+
+      - name: pylint
+        run: pylint zmk

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 fail_fast: false
 repos:
   - repo: https://github.com/psf/black
-    rev: "23.9.1"
+    rev: "24.8.0"
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
@@ -9,11 +9,11 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.2
+    rev: v1.5.5
     hooks:
       - id: remove-tabs
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,18 @@
 fail_fast: false
 repos:
-  - repo: https://github.com/psf/black
-    rev: "24.8.0"
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.17.0
     hooks:
-      - id: black
+      - id: pyupgrade
+        args: [--py310-plus]
   - repo: https://github.com/pycqa/isort
     rev: "5.13.2"
     hooks:
       - id: isort
+  - repo: https://github.com/psf/black
+    rev: "24.8.0"
+    hooks:
+      - id: black
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "ms-python.black-formatter",
+    "ms-python.isort",
+    "ms-python.python"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,7 @@
     "**/templates/common/**": "mako"
   },
   "isort.check": true,
-  "isort.args": ["--profile", "black"]
+  "isort.args": ["--settings-path", "${workspaceFolder}"],
+  "python.analysis.importFormat": "relative",
+  "python.analysis.typeCheckingMode": "standard"
 }

--- a/README.md
+++ b/README.md
@@ -239,3 +239,23 @@ For example, to point ZMK CLI to an existing repo at `~/Documents/zmk-config`, r
 ```sh
 zmk config user.home ~/Documents/zmk-config
 ```
+
+# Development
+
+If you would like to help improve ZMK CLI, you can clone this repo and install it in editable mode so your changes to the code apply when you run `zmk`. Open a terminal to the root directory of the repository and run:
+
+```sh
+pip install -e ".[dev]"
+pre-commit install
+```
+
+You may optionally run these commands inside a [virtual environment](https://docs.python.org/3/library/venv.html) if you don't want to install ZMK CLI's dependencies globally or if your OS disallows doing this.
+
+After running `pre-commit install`, your code will be checked when you make a commit, but there are some slower checks that do not run automatically. To run these additional checks, run these commands:
+
+```sh
+pyright .
+pylint zmk
+```
+
+Alternatively, you can just create a pull request and GitHub will run the checks and report any errors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,20 @@ build-backend = "setuptools.build_meta"
 [tool.isort]
 profile = "black"
 
+[tool.pylint.MAIN]
+ignore = "_version.py"
+
+[tool.pylint."MESSAGES CONTROL"]
+disable = [
+    "arguments-differ",             # Covered by pyright
+    "fixme",
+    "too-few-public-methods",
+    "too-many-arguments",
+    "too-many-branches",
+    "too-many-instance-attributes",
+    "too-many-locals",
+]
+
 [tool.setuptools]
 packages = ["zmk"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+dev = ["pre-commit", "pylint", "pyright"]
+
 [project.urls]
 Documentation = "https://zmk.dev/docs"
 "Source Code" = "https://github.com/zmkfirmware/zmk-cli/"

--- a/zmk/backports.py
+++ b/zmk/backports.py
@@ -2,6 +2,8 @@
 Backports from Python > 3.10.
 """
 
+# pyright: reportMissingImports = false
+
 try:
     # pylint: disable=unused-import
     from enum import StrEnum

--- a/zmk/build.py
+++ b/zmk/build.py
@@ -2,10 +2,10 @@
 Build matrix processing.
 """
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Optional, TypeVar, cast, overload
+from typing import Any, TypeVar, cast, overload
 
 import dacite
 
@@ -20,10 +20,10 @@ class BuildItem:
     """An item in the build matrix"""
 
     board: str
-    shield: Optional[str] = None
-    snippet: Optional[str] = None
-    cmake_args: Optional[str] = None
-    artifact_name: Optional[str] = None
+    shield: str | None = None
+    snippet: str | None = None
+    cmake_args: str | None = None
+    artifact_name: str | None = None
 
     def __rich__(self):
         parts = []

--- a/zmk/build.py
+++ b/zmk/build.py
@@ -5,7 +5,7 @@ Build matrix processing.
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, TypeVar, cast, overload
+from typing import Any, Self, TypeVar, cast, overload
 
 import dacite
 
@@ -25,7 +25,7 @@ class BuildItem:
     cmake_args: str | None = None
     artifact_name: str | None = None
 
-    def __rich__(self):
+    def __rich__(self) -> str:
         parts = []
         parts.append(self.board)
 
@@ -57,11 +57,11 @@ class BuildMatrix:
     _data: dict[str, Any] | None
 
     @classmethod
-    def from_repo(cls, repo: Repo):
+    def from_repo(cls, repo: Repo) -> Self:
         """Get the build matrix for a repo"""
         return cls(repo.build_matrix_path)
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path):
         self._path = path
         self._yaml = YAML(typ="rt")
         self._yaml.indent(mapping=2, sequence=4, offset=2)
@@ -70,12 +70,12 @@ class BuildMatrix:
         except FileNotFoundError:
             self._data = None
 
-    def write(self):
+    def write(self) -> None:
         """Updated the YAML file, creating it if necessary"""
         self._yaml.dump(self._data, self._path)
 
     @property
-    def path(self):
+    def path(self) -> Path:
         """Path to the matrix's YAML file"""
         return self._path
 
@@ -89,7 +89,7 @@ class BuildMatrix:
         wrapper = dacite.from_dict(_BuildMatrixWrapper, normalized)
         return wrapper.include
 
-    def has_item(self, item: BuildItem):
+    def has_item(self, item: BuildItem) -> bool:
         """Get whether the matrix has a build item"""
         return item in self.include
 

--- a/zmk/commands/__init__.py
+++ b/zmk/commands/__init__.py
@@ -7,7 +7,7 @@ import typer
 from . import cd, code, config, download, init, keyboard, module, west
 
 
-def register(app: typer.Typer):
+def register(app: typer.Typer) -> None:
     """Register all commands with the app"""
     app.command()(cd.cd)
     app.command()(code.code)

--- a/zmk/commands/cd.py
+++ b/zmk/commands/cd.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import shellingham
 import typer
 
-from ..config import Config
+from ..config import get_config
 from ..exceptions import FatalError, FatalHomeMissing, FatalHomeNotSet
 
 
@@ -22,7 +22,7 @@ def cd(ctx: typer.Context):
             'Use "cd $(zmk config user.home)" instead.'
         )
 
-    cfg = ctx.find_object(Config)
+    cfg = get_config(ctx)
     home = cfg.home_path
 
     if home is None:

--- a/zmk/commands/cd.py
+++ b/zmk/commands/cd.py
@@ -14,7 +14,7 @@ from ..config import get_config
 from ..exceptions import FatalError, FatalHomeMissing, FatalHomeNotSet
 
 
-def cd(ctx: typer.Context):
+def cd(ctx: typer.Context) -> None:
     """Go to the ZMK config repo."""
     if not sys.stdout.isatty():
         raise FatalError(

--- a/zmk/commands/code.py
+++ b/zmk/commands/code.py
@@ -40,7 +40,7 @@ def code(
             "--build", "-b", help="Open the build matrix instead of a keymap."
         ),
     ] = False,
-):
+) -> None:
     """Open the repo or a .keymap or .conf file in a text editor."""
 
     cfg = get_config(ctx)
@@ -110,7 +110,7 @@ class Editor:
     def __rich__(self):
         return self.name
 
-    def get_command(self):
+    def get_command(self) -> str | None:
         """Get the command to execute the tool, or None if it is not installed"""
         if self.test and self.test():
             return self.cmd

--- a/zmk/commands/code.py
+++ b/zmk/commands/code.py
@@ -6,10 +6,11 @@ import platform
 import shlex
 import shutil
 import subprocess
+from collections.abc import Callable
 from configparser import NoOptionError
 from dataclasses import dataclass, field
 from enum import Flag, auto
-from typing import Annotated, Callable, Optional
+from typing import Annotated
 
 import rich
 import typer
@@ -24,7 +25,7 @@ from ..repo import Repo
 def code(
     ctx: typer.Context,
     keyboard: Annotated[
-        Optional[str],
+        str | None,
         typer.Argument(
             help="Name of the keyboard to edit. If omitted, opens the repo directory.",
         ),
@@ -56,7 +57,7 @@ def code(
     subprocess.call(cmd, shell=True)
 
 
-def _get_file(repo: Repo, keyboard: Optional[str], open_conf: bool):
+def _get_file(repo: Repo, keyboard: str | None, open_conf: bool):
     if not keyboard:
         return repo.path
 

--- a/zmk/commands/config.py
+++ b/zmk/commands/config.py
@@ -8,7 +8,7 @@ import typer
 from rich.console import Console
 
 from .. import styles
-from ..config import Config
+from ..config import Config, get_config
 
 console = Console(
     highlighter=styles.KeyValueHighlighter(), theme=styles.KEY_VALUE_THEME
@@ -17,7 +17,7 @@ console = Console(
 
 def _path_callback(ctx: typer.Context, value: bool):
     if value:
-        cfg = ctx.find_object(Config)
+        cfg = get_config(ctx)
         print(cfg.path)
         raise typer.Exit()
 
@@ -51,7 +51,7 @@ def config(
 ):
     """Get and set ZMK CLI settings."""
 
-    cfg = ctx.find_object(Config)
+    cfg = get_config(ctx)
 
     if name is None:
         _list_settings(cfg)

--- a/zmk/commands/config.py
+++ b/zmk/commands/config.py
@@ -48,7 +48,7 @@ def config(
             callback=_path_callback,
         ),
     ] = False,
-):
+) -> None:
     """Get and set ZMK CLI settings."""
 
     cfg = get_config(ctx)

--- a/zmk/commands/config.py
+++ b/zmk/commands/config.py
@@ -2,7 +2,7 @@
 "zmk config" command.
 """
 
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 from rich.console import Console
@@ -25,13 +25,13 @@ def _path_callback(ctx: typer.Context, value: bool):
 def config(
     ctx: typer.Context,
     name: Annotated[
-        Optional[str],
+        str | None,
         typer.Argument(
             help="Setting name. Prints all setting values if omitted.",
         ),
     ] = None,
     value: Annotated[
-        Optional[str],
+        str | None,
         typer.Argument(help="New setting value. Prints the current value if omitted."),
     ] = None,
     unset: Annotated[
@@ -39,7 +39,7 @@ def config(
         typer.Option("--unset", "-u", help="Remove the setting with the given name."),
     ] = False,
     _: Annotated[
-        Optional[bool],
+        bool | None,
         typer.Option(
             "--path",
             "-p",

--- a/zmk/commands/download.py
+++ b/zmk/commands/download.py
@@ -4,14 +4,14 @@
 
 import typer
 
-from ..config import Config
+from ..config import get_config
 from ..repo import Repo
 
 
 def download(ctx: typer.Context):
     """Open the web page to download firmware from GitHub."""
 
-    cfg = ctx.find_object(Config)
+    cfg = get_config(ctx)
     repo = cfg.get_repo()
 
     actions_url = _get_actions_url(repo)

--- a/zmk/commands/download.py
+++ b/zmk/commands/download.py
@@ -8,7 +8,7 @@ from ..config import get_config
 from ..repo import Repo
 
 
-def download(ctx: typer.Context):
+def download(ctx: typer.Context) -> None:
     """Open the web page to download firmware from GitHub."""
 
     cfg = get_config(ctx)

--- a/zmk/commands/init.py
+++ b/zmk/commands/init.py
@@ -13,7 +13,7 @@ import typer
 from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
-from ..config import Config
+from ..config import Config, get_config
 from ..exceptions import FatalError
 from ..prompt import UrlPrompt
 from ..repo import Repo, find_containing_repo, is_repo
@@ -29,7 +29,7 @@ def init(ctx: typer.Context):
     """Create a new ZMK config repo or clone an existing one."""
 
     console = rich.get_console()
-    cfg = ctx.find_object(Config)
+    cfg = get_config(ctx)
 
     _check_dependencies()
     _check_for_existing_repo(cfg)

--- a/zmk/commands/init.py
+++ b/zmk/commands/init.py
@@ -25,7 +25,7 @@ TEMPLATE_URL = (
 TEXT_WIDTH = 80
 
 
-def init(ctx: typer.Context):
+def init(ctx: typer.Context) -> None:
     """Create a new ZMK config repo or clone an existing one."""
 
     console = rich.get_console()

--- a/zmk/commands/keyboard/__init__.py
+++ b/zmk/commands/keyboard/__init__.py
@@ -17,5 +17,5 @@ app.command(name="remove")(keyboard_remove)
 
 
 @app.callback()
-def keyboard():
+def keyboard() -> None:
     """Add or remove keyboards from the build."""

--- a/zmk/commands/keyboard/add.py
+++ b/zmk/commands/keyboard/add.py
@@ -40,7 +40,7 @@ def keyboard_add(
             help="ID of the keyboard board/shield to add.",
         ),
     ] = None,
-):
+) -> None:
     """Add configuration for a keyboard and add it to the build."""
 
     console = rich.get_console()

--- a/zmk/commands/keyboard/add.py
+++ b/zmk/commands/keyboard/add.py
@@ -5,7 +5,7 @@
 import itertools
 import shutil
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 import rich
 import typer
@@ -22,7 +22,7 @@ from ...util import spinner
 def keyboard_add(
     ctx: typer.Context,
     controller_id: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--controller",
             "-c",
@@ -31,7 +31,7 @@ def keyboard_add(
         ),
     ] = None,
     keyboard_id: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--keyboard",
             "--kb",
@@ -141,7 +141,7 @@ def _copy_keyboard_file(repo: Repo, path: Path):
         shutil.copy2(path, dest_path)
 
 
-def _get_build_items(keyboard: Keyboard, controller: Optional[Board]):
+def _get_build_items(keyboard: Keyboard, controller: Board | None):
     boards = []
     shields = []
 
@@ -162,7 +162,7 @@ def _get_build_items(keyboard: Keyboard, controller: Optional[Board]):
     return [BuildItem(board=b, shield=s) for b, s in itertools.product(boards, shields)]
 
 
-def _add_keyboard(repo: Repo, keyboard: Keyboard, controller: Optional[Board]):
+def _add_keyboard(repo: Repo, keyboard: Keyboard, controller: Board | None):
     _copy_keyboard_file(repo, keyboard.keymap_path)
     _copy_keyboard_file(repo, keyboard.config_path)
 

--- a/zmk/commands/keyboard/list.py
+++ b/zmk/commands/keyboard/list.py
@@ -2,7 +2,8 @@
 "zmk keyboard list" command.
 """
 
-from typing import Annotated, Iterable, Optional
+from collections.abc import Iterable
+from typing import Annotated
 
 import rich
 import typer
@@ -79,7 +80,7 @@ def _list_build_matrix(ctx: typer.Context, value: bool):
 def keyboard_list(
     ctx: typer.Context,
     _: Annotated[
-        Optional[bool],
+        bool | None,
         typer.Option(
             "--build",
             help="Show the build matrix.",
@@ -96,7 +97,7 @@ def keyboard_list(
         ),
     ] = ListType.ALL,
     board: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--board",
             "-b",
@@ -105,7 +106,7 @@ def keyboard_list(
         ),
     ] = None,
     shield: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--shield",
             "-s",
@@ -114,7 +115,7 @@ def keyboard_list(
         ),
     ] = None,
     interconnect: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--interconnect",
             "-i",

--- a/zmk/commands/keyboard/list.py
+++ b/zmk/commands/keyboard/list.py
@@ -129,7 +129,7 @@ def keyboard_list(
             "--standalone", help="List only keyboards with onboard controllers."
         ),
     ] = False,
-):
+) -> None:
     """List supported keyboards or keyboards in the build matrix."""
 
     console = rich.get_console()

--- a/zmk/commands/keyboard/new.py
+++ b/zmk/commands/keyboard/new.py
@@ -136,7 +136,7 @@ def keyboard_new(
     force: Annotated[
         bool, typer.Option("--force", "-f", help="Overwrite existing files.")
     ] = False,
-):
+) -> None:
     """Create a new keyboard from a template."""
     cfg = get_config(ctx)
     repo = cfg.get_repo()
@@ -257,11 +257,11 @@ class NamePrompt(NamePromptBase):
     """Prompt for a keyboard name."""
 
     @classmethod
-    def validate(cls, value: str):
+    def validate(cls, value: str) -> None:
         _validate_name(value)
 
     @classmethod
-    def ask(cls):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def ask(cls) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
         return super().ask("Enter the name of the keyboard")
 
 
@@ -269,11 +269,11 @@ class ShortNamePrompt(NamePromptBase):
     """Prompt for an abbreviated keyboard name."""
 
     @classmethod
-    def validate(cls, value: str):
+    def validate(cls, value: str) -> None:
         _validate_short_name(value)
 
     @classmethod
-    def ask(cls):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def ask(cls) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
         return super().ask(
             f"Enter an abbreviated name [dim](<= {MAX_NAME_LENGTH} chars)"
         )
@@ -283,11 +283,13 @@ class IdPrompt(NamePromptBase):
     """Prompt for a keyboard identifier."""
 
     @classmethod
-    def validate(cls, value: str):
+    def validate(cls, value: str) -> None:
         _validate_id(value)
 
     @classmethod
-    def ask(cls, prompt: str):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def ask(  # pyright: ignore[reportIncompatibleMethodOverride]
+        cls, prompt: str
+    ) -> str:
         result = super().ask(
             "Enter an ID for the keyboard", default=_get_default_id(prompt)
         )

--- a/zmk/commands/keyboard/new.py
+++ b/zmk/commands/keyboard/new.py
@@ -4,7 +4,7 @@
 
 import re
 from dataclasses import dataclass, field
-from typing import Annotated, Optional
+from typing import Annotated
 
 import rich
 import typer
@@ -76,19 +76,19 @@ def _validate_short_name(name: str):
         raise typer.BadParameter(f"Name must be <= {MAX_NAME_LENGTH} characters.")
 
 
-def _id_callback(value: Optional[str]):
+def _id_callback(value: str | None):
     if value is not None:
         _validate_id(value)
     return value
 
 
-def _name_callback(name: Optional[str]):
+def _name_callback(name: str | None):
     if name is not None:
         _validate_name(name)
     return name
 
 
-def _short_name_callback(name: Optional[str]):
+def _short_name_callback(name: str | None):
     if name is not None:
         _validate_short_name(name)
     return name
@@ -97,15 +97,15 @@ def _short_name_callback(name: Optional[str]):
 def keyboard_new(
     ctx: typer.Context,
     keyboard_id: Annotated[
-        Optional[str],
+        str | None,
         typer.Option("--id", "-i", help="Board/shield ID.", callback=_id_callback),
     ] = None,
     keyboard_name: Annotated[
-        Optional[str],
+        str | None,
         typer.Option("--name", "-n", help="Keyboard name.", callback=_name_callback),
     ] = None,
     short_name: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--shortname",
             "-s",
@@ -114,7 +114,7 @@ def keyboard_new(
         ),
     ] = None,
     keyboard_type: Annotated[
-        Optional[KeyboardType],
+        KeyboardType | None,
         typer.Option(
             "--type",
             "-t",
@@ -122,7 +122,7 @@ def keyboard_new(
         ),
     ] = None,
     keyboard_platform: Annotated[
-        Optional[KeyboardPlatform],
+        KeyboardPlatform | None,
         typer.Option(
             "--platform",
             "-p",
@@ -130,7 +130,7 @@ def keyboard_new(
         ),
     ] = None,
     keyboard_layout: Annotated[
-        Optional[KeyboardLayout],
+        KeyboardLayout | None,
         typer.Option("--layout", "-l", help="Keyboard hardware layout."),
     ] = None,
     force: Annotated[

--- a/zmk/commands/keyboard/remove.py
+++ b/zmk/commands/keyboard/remove.py
@@ -11,7 +11,7 @@ from ...menu import show_menu
 
 
 # TODO: add options to select items from command line
-def keyboard_remove(ctx: typer.Context):
+def keyboard_remove(ctx: typer.Context) -> None:
     """Remove a keyboard from the build."""
     cfg = get_config(ctx)
     repo = cfg.get_repo()

--- a/zmk/commands/keyboard/remove.py
+++ b/zmk/commands/keyboard/remove.py
@@ -6,14 +6,14 @@ import rich
 import typer
 
 from ...build import BuildMatrix
+from ...config import get_config
 from ...menu import show_menu
-from ..config import Config
 
 
 # TODO: add options to select items from command line
 def keyboard_remove(ctx: typer.Context):
     """Remove a keyboard from the build."""
-    cfg = ctx.find_object(Config)
+    cfg = get_config(ctx)
     repo = cfg.get_repo()
 
     matrix = BuildMatrix.from_repo(repo)

--- a/zmk/commands/module/__init__.py
+++ b/zmk/commands/module/__init__.py
@@ -15,5 +15,5 @@ app.command(name="remove")(module_remove)
 
 
 @app.callback()
-def keyboard():
+def keyboard() -> None:
     """Add or remove Zephyr modules from the build."""

--- a/zmk/commands/module/add.py
+++ b/zmk/commands/module/add.py
@@ -11,7 +11,7 @@ from rich.console import Console
 from rich.prompt import InvalidResponse, Prompt, PromptBase
 from west.manifest import ImportFlag, Manifest
 
-from ...config import Config
+from ...config import get_config
 from ...exceptions import FatalError
 from ...prompt import UrlPrompt
 from ...util import spinner
@@ -34,7 +34,7 @@ def module_add(
     ] = None,
 ):
     """Add a Zephyr module to the build."""
-    cfg = ctx.find_object(Config)
+    cfg = get_config(ctx)
     repo = cfg.get_repo()
 
     manifest = Manifest.from_topdir(
@@ -88,7 +88,7 @@ def _get_name_from_url(repo_url: str):
     return repo_url.split("/")[-1].removesuffix(".git")
 
 
-class NamePrompt(PromptBase):
+class NamePrompt(PromptBase[str]):
     """Prompt for a module name."""
 
     _manifest: Manifest
@@ -97,11 +97,12 @@ class NamePrompt(PromptBase):
         super().__init__("Enter a new name", console=console)
         self._manifest = manifest
 
-    # pylint: disable=arguments-renamed, arguments-differ
     @classmethod
-    def ask(cls, manifest: Manifest, *, console: Optional[Console] = None):
-        prompt = cls(manifest, console=console)
-        return prompt()
+    def ask(  # pyright: ignore[reportIncompatibleMethodOverride]
+        cls, prompt: Manifest, *, console: Optional[Console] = None
+    ):
+        subprompt = cls(prompt, console=console)
+        return subprompt()
 
     def process_response(self, value: str) -> str:
         value = value.strip()

--- a/zmk/commands/module/add.py
+++ b/zmk/commands/module/add.py
@@ -3,7 +3,7 @@
 """
 
 import subprocess
-from typing import Annotated, Optional
+from typing import Annotated
 
 import rich
 import typer
@@ -21,15 +21,15 @@ from ...yaml import YAML
 def module_add(
     ctx: typer.Context,
     url: Annotated[
-        Optional[str],
+        str | None,
         typer.Argument(help="URL of the Git repository to add.", show_default=False),
     ] = None,
     revision: Annotated[
-        Optional[str],
+        str | None,
         typer.Argument(help="Revision to track.", show_default="main"),
     ] = None,
     name: Annotated[
-        Optional[str],
+        str | None,
         typer.Option("--name", "-n", help="Name of the module.", show_default=False),
     ] = None,
 ):
@@ -93,13 +93,13 @@ class NamePrompt(PromptBase[str]):
 
     _manifest: Manifest
 
-    def __init__(self, manifest: Manifest, *, console: Optional[Console] = None):
+    def __init__(self, manifest: Manifest, *, console: Console | None = None):
         super().__init__("Enter a new name", console=console)
         self._manifest = manifest
 
     @classmethod
     def ask(  # pyright: ignore[reportIncompatibleMethodOverride]
-        cls, prompt: Manifest, *, console: Optional[Console] = None
+        cls, prompt: Manifest, *, console: Console | None = None
     ):
         subprompt = cls(prompt, console=console)
         return subprompt()

--- a/zmk/commands/module/add.py
+++ b/zmk/commands/module/add.py
@@ -32,7 +32,7 @@ def module_add(
         str | None,
         typer.Option("--name", "-n", help="Name of the module.", show_default=False),
     ] = None,
-):
+) -> None:
     """Add a Zephyr module to the build."""
     cfg = get_config(ctx)
     repo = cfg.get_repo()

--- a/zmk/commands/module/list.py
+++ b/zmk/commands/module/list.py
@@ -8,7 +8,7 @@ from rich import box
 from rich.table import Table
 from west.manifest import ImportFlag, Manifest
 
-from ...config import Config
+from ...config import get_config
 
 
 def module_list(
@@ -18,7 +18,7 @@ def module_list(
 
     console = rich.get_console()
 
-    cfg = ctx.find_object(Config)
+    cfg = get_config(ctx)
     repo = cfg.get_repo()
 
     manifest = Manifest.from_topdir(

--- a/zmk/commands/module/list.py
+++ b/zmk/commands/module/list.py
@@ -11,9 +11,7 @@ from west.manifest import ImportFlag, Manifest
 from ...config import get_config
 
 
-def module_list(
-    ctx: typer.Context,
-):
+def module_list(ctx: typer.Context) -> None:
     """Print a list of installed Zephyr modules."""
 
     console = rich.get_console()

--- a/zmk/commands/module/remove.py
+++ b/zmk/commands/module/remove.py
@@ -13,7 +13,7 @@ import rich
 import typer
 from west.manifest import ImportFlag, Manifest, Project
 
-from ...config import Config
+from ...config import get_config
 from ...exceptions import FatalError
 from ...menu import Detail, detail_list, show_menu
 from ...repo import Repo
@@ -29,7 +29,7 @@ def module_remove(
     ] = None,
 ):
     """Remove a Zephyr module from the build."""
-    cfg = ctx.find_object(Config)
+    cfg = get_config(ctx)
     repo = cfg.get_repo()
 
     manifest = Manifest.from_topdir(

--- a/zmk/commands/module/remove.py
+++ b/zmk/commands/module/remove.py
@@ -7,7 +7,7 @@ import shutil
 import stat
 import subprocess
 from dataclasses import dataclass
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any
 
 import rich
 import typer
@@ -24,7 +24,7 @@ from ...yaml import YAML
 def module_remove(
     ctx: typer.Context,
     module: Annotated[
-        Optional[str],
+        str | None,
         typer.Argument(help="Name or URL of the module to remove.", show_default=False),
     ] = None,
 ):

--- a/zmk/commands/module/remove.py
+++ b/zmk/commands/module/remove.py
@@ -27,7 +27,7 @@ def module_remove(
         str | None,
         typer.Argument(help="Name or URL of the module to remove.", show_default=False),
     ] = None,
-):
+) -> None:
     """Remove a Zephyr module from the build."""
     cfg = get_config(ctx)
     repo = cfg.get_repo()

--- a/zmk/commands/west.py
+++ b/zmk/commands/west.py
@@ -6,7 +6,7 @@ from typing import Annotated, Optional
 
 import typer
 
-from ..config import Config
+from ..config import get_config
 
 
 def west(ctx: typer.Context):
@@ -15,7 +15,7 @@ def west(ctx: typer.Context):
     Run [link=https://docs.zephyrproject.org/latest/develop/west/index.html]west[/link] in the config repo.
     """
 
-    cfg = ctx.find_object(Config)
+    cfg = get_config(ctx)
     repo = cfg.get_repo()
 
     # TODO: detect this better
@@ -37,7 +37,7 @@ def update(
 ):
     """Fetch the latest keyboard data."""
 
-    cfg = ctx.find_object(Config)
+    cfg = get_config(ctx)
     repo = cfg.get_repo()
 
     modules = modules or []

--- a/zmk/commands/west.py
+++ b/zmk/commands/west.py
@@ -9,7 +9,7 @@ import typer
 from ..config import get_config
 
 
-def west(ctx: typer.Context):
+def west(ctx: typer.Context) -> None:
     # pylint: disable=line-too-long
     """
     Run [link=https://docs.zephyrproject.org/latest/develop/west/index.html]west[/link] in the config repo.
@@ -34,7 +34,7 @@ def update(
             help="Names of modules to update. Updates all modules if omitted."
         ),
     ] = None,
-):
+) -> None:
     """Fetch the latest keyboard data."""
 
     cfg = get_config(ctx)

--- a/zmk/commands/west.py
+++ b/zmk/commands/west.py
@@ -2,7 +2,7 @@
 "zmk west" command.
 """
 
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 
@@ -29,7 +29,7 @@ def west(ctx: typer.Context):
 def update(
     ctx: typer.Context,
     modules: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Argument(
             help="Names of modules to update. Updates all modules if omitted."
         ),

--- a/zmk/config.py
+++ b/zmk/config.py
@@ -30,7 +30,7 @@ class Config:
     path: Path
     force_home: bool
 
-    def __init__(self, path: Path, force_home=False) -> None:
+    def __init__(self, path: Optional[Path], force_home=False) -> None:
         self.path = path or _default_config_path()
         self.force_home = force_home
 
@@ -117,6 +117,15 @@ class Config:
             raise FatalHomeMissing(home)
 
         return Repo(home)
+
+
+def get_config(ctx: typer.Context) -> Config:
+    """Get the Config object for the given context"""
+
+    cfg = ctx.find_object(Config)
+    if cfg is None:
+        raise RuntimeError("Could not find Config for current context")
+    return cfg
 
 
 def _default_config_path():

--- a/zmk/config.py
+++ b/zmk/config.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from configparser import ConfigParser
 from itertools import chain
 from pathlib import Path
-from typing import Optional
 
 import typer
 
@@ -30,7 +29,7 @@ class Config:
     path: Path
     force_home: bool
 
-    def __init__(self, path: Optional[Path], force_home=False) -> None:
+    def __init__(self, path: Path | None, force_home=False) -> None:
         self.path = path or _default_config_path()
         self.force_home = force_home
 
@@ -86,7 +85,7 @@ class Config:
     # Shortcuts for commonly-used settings:
 
     @property
-    def home_path(self) -> Optional[Path]:
+    def home_path(self) -> Path | None:
         """
         Path to ZMK config repo.
         """

--- a/zmk/config.py
+++ b/zmk/config.py
@@ -3,6 +3,7 @@ User configuration.
 """
 
 from collections import defaultdict
+from collections.abc import Generator
 from configparser import ConfigParser
 from itertools import chain
 from pathlib import Path
@@ -29,7 +30,7 @@ class Config:
     path: Path
     force_home: bool
 
-    def __init__(self, path: Path | None, force_home=False) -> None:
+    def __init__(self, path: Path | None, force_home=False):
         self.path = path or _default_config_path()
         self.force_home = force_home
 
@@ -37,7 +38,7 @@ class Config:
         self._parser = ConfigParser()
         self._parser.read(self.path, encoding="utf-8")
 
-    def write(self):
+    def write(self) -> None:
         """Write back to the same file used when calling read()"""
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -54,17 +55,17 @@ class Config:
         section, option = self._split_option(name)
         return self._parser.getboolean(section, option, **kwargs)
 
-    def set(self, name: str, value: str):
+    def set(self, name: str, value: str) -> None:
         """Set a setting"""
         section, option = self._split_option(name)
         self._parser.set(section, option, value)
 
-    def remove(self, name: str):
+    def remove(self, name: str) -> None:
         """Remove a setting"""
         section, option = self._split_option(name)
         self._parser.remove_option(section, option)
 
-    def items(self):
+    def items(self) -> Generator[tuple[str, str], None, None]:
         """Yields ('section.option', 'value') tuples for all settings"""
         sections = set(chain(self._overrides.keys(), self._parser.sections()))
 
@@ -93,7 +94,7 @@ class Config:
         return Path(home) if home else None
 
     @home_path.setter
-    def home_path(self, value: Path):
+    def home_path(self, value: Path) -> None:
         self.set(Settings.USER_HOME, str(value.resolve()))
 
     def get_repo(self) -> Repo:

--- a/zmk/exceptions.py
+++ b/zmk/exceptions.py
@@ -3,7 +3,7 @@ Exception types.
 """
 
 from pathlib import Path
-from typing import Optional, cast
+from typing import cast
 
 from click import ClickException
 from rich.highlighter import Highlighter, ReprHighlighter
@@ -19,7 +19,7 @@ class FatalError(ClickException):
 
     highlighter: Highlighter
 
-    def __init__(self, message: str, highlighter: Optional[Highlighter] = None) -> None:
+    def __init__(self, message: str, highlighter: Highlighter | None = None) -> None:
         self.highlighter = highlighter or ReprHighlighter()
         super().__init__(message)
 

--- a/zmk/exceptions.py
+++ b/zmk/exceptions.py
@@ -3,6 +3,7 @@ Exception types.
 """
 
 from pathlib import Path
+from typing import Optional, cast
 
 from click import ClickException
 from rich.highlighter import Highlighter, ReprHighlighter
@@ -18,12 +19,14 @@ class FatalError(ClickException):
 
     highlighter: Highlighter
 
-    def __init__(self, message: str, highlighter: Highlighter = None) -> None:
+    def __init__(self, message: str, highlighter: Optional[Highlighter] = None) -> None:
         self.highlighter = highlighter or ReprHighlighter()
         super().__init__(message)
 
     def format_message(self) -> str:
-        return self.highlighter(Text.from_markup(self.message))
+        # format_message() expects a str, but if we convert to a string here,
+        # we will lose any formatting.
+        return cast(str, self.highlighter(Text.from_markup(self.message)))
 
 
 class FatalHomeNotSet(FatalError):

--- a/zmk/exceptions.py
+++ b/zmk/exceptions.py
@@ -19,7 +19,7 @@ class FatalError(ClickException):
 
     highlighter: Highlighter
 
-    def __init__(self, message: str, highlighter: Highlighter | None = None) -> None:
+    def __init__(self, message: str, highlighter: Highlighter | None = None):
         self.highlighter = highlighter or ReprHighlighter()
         super().__init__(message)
 

--- a/zmk/hardware.py
+++ b/zmk/hardware.py
@@ -2,10 +2,11 @@
 Hardware metadata discovery and processing.
 """
 
+from collections.abc import Generator, Iterable
 from dataclasses import dataclass, field
 from functools import reduce
 from pathlib import Path
-from typing import Any, Generator, Iterable, Literal, Optional, TypeAlias, TypeGuard
+from typing import Any, Literal, TypeAlias, TypeGuard
 
 import dacite
 
@@ -33,11 +34,11 @@ class Hardware:
     id: str
     name: str
 
-    file_format: Optional[str] = None
-    url: Optional[str] = None
-    description: Optional[str] = None
-    manufacturer: Optional[str] = None
-    version: Optional[str] = None
+    file_format: str | None = None
+    url: str | None = None
+    description: str | None = None
+    manufacturer: str | None = None
+    version: str | None = None
 
     def __str__(self) -> str:
         return self.id
@@ -56,20 +57,20 @@ class Interconnect(Hardware):
     """Description of the connection between two pieces of hardware"""
 
     node_labels: dict[str, str] = field(default_factory=dict)
-    design_guideline: Optional[str] = None
+    design_guideline: str | None = None
 
 
 @dataclass
 class Keyboard(Hardware):
     """Base class for hardware that forms a keyboard"""
 
-    siblings: Optional[list[str]] = field(default_factory=list)
+    siblings: list[str] | None = field(default_factory=list)
     """List of board/shield IDs for a split keyboard"""
-    exposes: Optional[list[str]] = field(default_factory=list)
+    exposes: list[str] | None = field(default_factory=list)
     """List of interconnect IDs this board/shield provides"""
-    features: Optional[list[Feature]] = field(default_factory=list)
+    features: list[Feature] | None = field(default_factory=list)
     """List of features this board/shield supports"""
-    variants: Optional[list[Variant]] = field(default_factory=list)
+    variants: list[Variant] | None = field(default_factory=list)
 
     def __post_init__(self):
         self.siblings = self.siblings or []
@@ -92,7 +93,7 @@ class Keyboard(Hardware):
 class Board(Keyboard):
     """Hardware with a processor. May be a keyboard or a controller."""
 
-    arch: Optional[str] = None
+    arch: str | None = None
     outputs: list[Output] = field(default_factory=list)
     """List of methods by which this board supports sending HID data"""
 
@@ -105,7 +106,7 @@ class Board(Keyboard):
 class Shield(Keyboard):
     """Hardware that attaches to a board. May be a keyboard or a peripheral."""
 
-    requires: Optional[list[str]] = field(default_factory=list)
+    requires: list[str] | None = field(default_factory=list)
     """List of interconnects to which this shield attaches"""
 
     def __post_init__(self):

--- a/zmk/hardware.py
+++ b/zmk/hardware.py
@@ -148,7 +148,7 @@ class GroupedHardware:
 def is_keyboard(hardware: Hardware) -> TypeGuard[Keyboard]:
     """Test whether an item is a keyboard (board or shield supporting keys)"""
     match hardware:
-        case Keyboard(features=feat) if "keys" in feat:
+        case Keyboard(features=feat) if feat and "keys" in feat:
             return True
 
         case _:
@@ -174,6 +174,9 @@ def is_compatible(base: Board | Shield | Iterable[Board | Shield], shield: Shiel
     not account for the fact that one of the items in "base" may already be using
     an interconnect provided by another item.
     """
+
+    if not shield.requires:
+        return True
 
     base = [base] if isinstance(base, Keyboard) else base
     exposed = flatten(b.exposes for b in base)

--- a/zmk/hardware.py
+++ b/zmk/hardware.py
@@ -6,7 +6,7 @@ from collections.abc import Generator, Iterable
 from dataclasses import dataclass, field
 from functools import reduce
 from pathlib import Path
-from typing import Any, Literal, TypeAlias, TypeGuard
+from typing import Any, Literal, Self, TypeAlias, TypeGuard
 
 import dacite
 
@@ -47,7 +47,7 @@ class Hardware:
         return f"{self.id}  [dim]{self.name}"
 
     @classmethod
-    def from_dict(cls, data):
+    def from_dict(cls, data) -> Self:
         """Read a hardware description from a dict"""
         return dacite.from_dict(cls, data)
 
@@ -79,12 +79,12 @@ class Keyboard(Hardware):
         self.variants = self.variants or []
 
     @property
-    def config_path(self):
+    def config_path(self) -> Path:
         """Path to the .conf file for this keyboard"""
         return self.directory / f"{self.id}.conf"
 
     @property
-    def keymap_path(self):
+    def keymap_path(self) -> Path:
         """Path to the .keymap file for this keyboard"""
         return self.directory / f"{self.id}.keymap"
 
@@ -127,17 +127,17 @@ class GroupedHardware:
 
     # TODO: add displays and other peripherals?
 
-    def find_keyboard(self, item_id: str):
+    def find_keyboard(self, item_id: str) -> Keyboard | None:
         """Find a keyboard by ID"""
         item_id = item_id.casefold()
         return next((i for i in self.keyboards if i.id.casefold() == item_id), None)
 
-    def find_controller(self, item_id: str):
+    def find_controller(self, item_id: str) -> Board | None:
         """Find a controller by ID"""
         item_id = item_id.casefold()
         return next((i for i in self.controllers if i.id.casefold() == item_id), None)
 
-    def find_interconnect(self, item_id: str):
+    def find_interconnect(self, item_id: str) -> Interconnect | None:
         """Find an interconnect by ID"""
         item_id = item_id.casefold()
         return next(
@@ -166,7 +166,9 @@ def is_interconnect(hardware: Hardware) -> TypeGuard[Interconnect]:
     return isinstance(hardware, Interconnect)
 
 
-def is_compatible(base: Board | Shield | Iterable[Board | Shield], shield: Shield):
+def is_compatible(
+    base: Board | Shield | Iterable[Board | Shield], shield: Shield
+) -> bool:
     """
     Get whether a shield can be attached to the given hardware.
 

--- a/zmk/main.py
+++ b/zmk/main.py
@@ -45,7 +45,7 @@ def main(
             callback=_version_callback,
             is_eager=True,
         ),
-    ] = None,
+    ] = False,
 ):
     """
     ZMK Firmware command line tool

--- a/zmk/main.py
+++ b/zmk/main.py
@@ -4,7 +4,7 @@ CLI tool to setup up ZMK Firmware.
 
 from importlib import metadata
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 
@@ -25,7 +25,7 @@ def _version_callback(version: bool):
 def main(
     ctx: typer.Context,
     config_file: Annotated[
-        Optional[Path],
+        Path | None,
         typer.Option(
             envvar="ZMK_CLI_CONFIG", help="Path to the ZMK CLI configuration file."
         ),

--- a/zmk/main.py
+++ b/zmk/main.py
@@ -46,7 +46,7 @@ def main(
             is_eager=True,
         ),
     ] = False,
-):
+) -> None:
     """
     ZMK Firmware command line tool
 

--- a/zmk/menu.py
+++ b/zmk/menu.py
@@ -2,8 +2,9 @@
 Terminal menus
 """
 
+from collections.abc import Callable, Iterable
 from contextlib import contextmanager
-from typing import Any, Callable, Generic, Iterable, Optional, TypeVar
+from typing import Any, Generic, TypeVar
 
 import rich
 from rich.console import Console
@@ -53,7 +54,7 @@ class TerminalMenu(Generic[T], Highlighter):
     items: list[T]
     default_index: int
 
-    _filter_func: Optional[Callable[[T, str], bool]]
+    _filter_func: Callable[[T, str], bool] | None
     _filter_text: str
     _filter_items: list[T]
     _cursor_index: int
@@ -70,9 +71,9 @@ class TerminalMenu(Generic[T], Highlighter):
         items: Iterable[T],
         *,
         default_index=0,
-        filter_func: Optional[Callable[[T, str], bool]] = None,
-        console: Optional[Console] = None,
-        theme: Optional[Theme] = None,
+        filter_func: Callable[[T, str], bool] | None = None,
+        console: Console | None = None,
+        theme: Theme | None = None,
     ):
         """
         An interactive terminal menu.
@@ -407,9 +408,9 @@ def show_menu(
     items: Iterable[T],
     *,
     default_index=0,
-    filter_func: Optional[Callable[[T, str], bool]] = None,
-    console: Optional[Console] = None,
-    theme: Optional[Theme] = None,
+    filter_func: Callable[[T, str], bool] | None = None,
+    console: Console | None = None,
+    theme: Theme | None = None,
 ):
     """
     Displays an interactive menu.
@@ -458,7 +459,7 @@ class Detail(Generic[T]):
 
     # pylint: disable=protected-access
     @classmethod
-    def align(cls, items: Iterable["Detail[T]"], console: Optional[Console] = None):
+    def align(cls, items: Iterable["Detail[T]"], console: Console | None = None):
         """Set the padding for each item in the list to align the detail strings."""
         items = list(items)
         console = console or rich.get_console()
@@ -475,7 +476,7 @@ class Detail(Generic[T]):
 
 
 def detail_list(
-    items: Iterable[tuple[T, str]], console: Optional[Console] = None
+    items: Iterable[tuple[T, str]], console: Console | None = None
 ) -> list[Detail[T]]:
     """
     Create a list of menu items with a description appended to each item.

--- a/zmk/menu.py
+++ b/zmk/menu.py
@@ -180,7 +180,7 @@ class TerminalMenu(Generic[T], Highlighter):
             self.console.highlighter = old_highlighter
 
     def _apply_filter(self):
-        if self.has_filter:
+        if self._filter_func:
             try:
                 old_focus = self._filter_items[self._focus_index]
             except IndexError:
@@ -190,10 +190,11 @@ class TerminalMenu(Generic[T], Highlighter):
                 i for i in self.items if self._filter_func(i, self._filter_text)
             ]
 
-            try:
-                self._focus_index = self._filter_items.index(old_focus)
-            except ValueError:
-                pass
+            if old_focus is not None:
+                try:
+                    self._focus_index = self._filter_items.index(old_focus)
+                except ValueError:
+                    pass
         else:
             self._filter_items = self.items
 
@@ -246,7 +247,7 @@ class TerminalMenu(Generic[T], Highlighter):
             overflow="crop",
         )
 
-    def _print_item(self, item: T, focused: bool, show_more: bool):
+    def _print_item(self, item: T | str, focused: bool, show_more: bool):
         style = "ellipsis" if show_more else "focus" if focused else "unfocus"
 
         indent = "> " if focused else "  "

--- a/zmk/menu.py
+++ b/zmk/menu.py
@@ -113,7 +113,7 @@ class TerminalMenu(Generic[T], Highlighter):
 
         self._apply_filter()
 
-    def show(self):
+    def show(self) -> T:
         """
         Displays the menu.
 
@@ -147,11 +147,11 @@ class TerminalMenu(Generic[T], Highlighter):
             self._erase_controls()
 
     @property
-    def has_filter(self):
+    def has_filter(self) -> bool:
         """Get whether a filter function is set"""
         return bool(self._filter_func)
 
-    def highlight(self, text: Text):
+    def highlight(self, text: Text) -> None:
         normfilter = self._filter_text.casefold().strip()
         if not normfilter:
             return
@@ -411,7 +411,7 @@ def show_menu(
     filter_func: Callable[[T, str], bool] | None = None,
     console: Console | None = None,
     theme: Theme | None = None,
-):
+) -> T:
     """
     Displays an interactive menu.
 
@@ -459,7 +459,9 @@ class Detail(Generic[T]):
 
     # pylint: disable=protected-access
     @classmethod
-    def align(cls, items: Iterable["Detail[T]"], console: Console | None = None):
+    def align(
+        cls, items: Iterable["Detail[T]"], console: Console | None = None
+    ) -> list["Detail[T]"]:
         """Set the padding for each item in the list to align the detail strings."""
         items = list(items)
         console = console or rich.get_console()

--- a/zmk/prompt.py
+++ b/zmk/prompt.py
@@ -5,7 +5,7 @@ Prompt classes.
 from rich.prompt import InvalidResponse, PromptBase
 
 
-class UrlPrompt(PromptBase):
+class UrlPrompt(PromptBase[str]):
     """Prompt for a URL."""
 
     def process_response(self, value: str) -> str:

--- a/zmk/repo.py
+++ b/zmk/repo.py
@@ -7,7 +7,7 @@ import subprocess
 from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
-from typing import Any, Generator, Optional
+from typing import Any, Generator, Literal, Optional, overload
 
 from west.app.main import main as west_main
 
@@ -127,6 +127,15 @@ class Repo(Module):
         """Path to the west staging folder."""
         return self.path / _WEST_STAGING_PATH
 
+    @overload
+    def git(self, *args: str, capture_output: Literal[False] = False) -> None: ...
+
+    @overload
+    def git(self, *args: str, capture_output: Literal[True]) -> str: ...
+
+    @overload
+    def git(self, *args: str, capture_output: bool) -> str | None: ...
+
     def git(self, *args: str, capture_output: bool = False) -> str | None:
         """
         Run Git in the repo.
@@ -134,7 +143,7 @@ class Repo(Module):
         If capture_output is True, the command is run silently in the background
         and this returns the output as a string.
         """
-        args = ["git", *args]
+        args = ("git", *args)
 
         if capture_output:
             return subprocess.check_output(
@@ -144,7 +153,16 @@ class Repo(Module):
         subprocess.check_call(args, encoding="utf-8")
         return None
 
-    def run_west(self, *args: str, capture_output: bool = False) -> str | None:
+    @overload
+    def run_west(self, *args: str, capture_output: Literal[False] = False) -> None: ...
+
+    @overload
+    def run_west(self, *args: str, capture_output: Literal[True]) -> str: ...
+
+    @overload
+    def run_west(self, *args: str, capture_output: bool) -> str | None: ...
+
+    def run_west(self, *args: str, capture_output: bool = False):
         """
         Run west in the west staging folder.
 
@@ -171,6 +189,15 @@ class Repo(Module):
             self._init_west_app()
 
         self._west_ready = True
+
+    @overload
+    def _run_west(self, *args: str, capture_output: Literal[False] = False) -> None: ...
+
+    @overload
+    def _run_west(self, *args: str, capture_output: Literal[True]) -> str: ...
+
+    @overload
+    def _run_west(self, *args: str, capture_output: bool) -> str | None: ...
 
     def _run_west(self, *args: str, capture_output=False):
         if capture_output:

--- a/zmk/repo.py
+++ b/zmk/repo.py
@@ -4,10 +4,11 @@ Config repo and Zephyr module utilities.
 
 import shutil
 import subprocess
+from collections.abc import Generator
 from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
-from typing import Any, Generator, Literal, Optional, overload
+from typing import Any, Literal, overload
 
 from west.app.main import main as west_main
 
@@ -28,7 +29,7 @@ def is_repo(path: Path) -> bool:
     return (path / _PROJECT_MANIFEST_PATH).is_file()
 
 
-def find_containing_repo(path: Optional[Path] = None) -> Optional[Path]:
+def find_containing_repo(path: Path | None = None) -> Path | None:
     """Search upwards from the given path for a ZMK config repo."""
     path = path or Path()
     path = path.absolute()
@@ -52,7 +53,7 @@ class Module:
         return self.path / _MODULE_MANIFEST_PATH
 
     @property
-    def board_root(self) -> Optional[Path]:
+    def board_root(self) -> Path | None:
         """Path to the "boards" folder."""
 
         # Check for board_root from module manifest
@@ -93,7 +94,7 @@ class Repo(Module):
         return self.path / _PROJECT_MANIFEST_PATH
 
     @property
-    def board_root(self) -> Optional[Path]:
+    def board_root(self) -> Path | None:
         if root := super().board_root:
             return root
 

--- a/zmk/repo.py
+++ b/zmk/repo.py
@@ -175,7 +175,7 @@ class Repo(Module):
         self.ensure_west_ready()
         return self._run_west(*args, capture_output=capture_output)
 
-    def ensure_west_ready(self):
+    def ensure_west_ready(self) -> None:
         """
         Ensures the west application is correctly initialized.
         """

--- a/zmk/templates/__init__.py
+++ b/zmk/templates/__init__.py
@@ -12,9 +12,8 @@ Templates will be provided the following parameters:
 """
 
 import re
-from itertools import pairwise
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any, Generator, cast
 
 from mako.lookup import TemplateLookup
 from mako.template import Template
@@ -43,8 +42,8 @@ def get_template_files(
         file_name = Template(text=file.name, strict_undefined=True)
 
         yield (
-            file_name.render_unicode(**data),
-            _ensure_trailing_newline(template.render_unicode(**data)),
+            cast(str, file_name.render_unicode(**data)),
+            _ensure_trailing_newline(cast(str, template.render_unicode(**data))),
         )
 
 

--- a/zmk/templates/__init__.py
+++ b/zmk/templates/__init__.py
@@ -12,8 +12,9 @@ Templates will be provided the following parameters:
 """
 
 import re
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Generator, cast
+from typing import Any, cast
 
 from mako.lookup import TemplateLookup
 from mako.template import Template

--- a/zmk/terminal.py
+++ b/zmk/terminal.py
@@ -2,6 +2,12 @@
 Terminal utilities
 """
 
+# Ignore missing attributes for platform-specific modules
+# pyright: reportAttributeAccessIssue = false
+
+# Ignore alternative declarations of the same functions
+# pyright: reportRedeclaration = false
+
 import os
 import sys
 from contextlib import contextmanager

--- a/zmk/terminal.py
+++ b/zmk/terminal.py
@@ -10,16 +10,17 @@ Terminal utilities
 
 import os
 import sys
+from collections.abc import Generator
 from contextlib import contextmanager
 
 
-def hide_cursor():
+def hide_cursor() -> None:
     """Hides the terminal cursor."""
     sys.stdout.write("\x1b[?25l")
     sys.stdout.flush()
 
 
-def show_cursor():
+def show_cursor() -> None:
     """Unhides the terminal cursor."""
     sys.stdout.write("\x1b[?25h")
     sys.stdout.flush()
@@ -68,7 +69,7 @@ try:
         83: DELETE,
     }
 
-    def read_key():
+    def read_key() -> bytes:
         """
         Waits for a key to be pressed and returns it.
 
@@ -89,7 +90,7 @@ try:
         return key
 
     @contextmanager
-    def enable_vt_mode():
+    def enable_vt_mode() -> Generator[None, None, None]:
         """
         Context manager which enables virtual terminal processing.
         """
@@ -108,7 +109,7 @@ try:
             kernel32.SetConsoleMode(stdout_handle, old_stdout_mode)
 
     @contextmanager
-    def disable_echo():
+    def disable_echo() -> Generator[None, None, None]:
         """
         Context manager which disables console echo
         """
@@ -128,7 +129,7 @@ except ImportError:
     import termios
 
     @contextmanager
-    def enable_vt_mode():
+    def enable_vt_mode() -> Generator[None, None, None]:
         """
         Context manager which enables virtual terminal processing.
         """
@@ -136,7 +137,7 @@ except ImportError:
         yield
 
     @contextmanager
-    def disable_echo():
+    def disable_echo() -> Generator[None, None, None]:
         """
         Context manager which disables console echo
         """
@@ -150,7 +151,7 @@ except ImportError:
         finally:
             termios.tcsetattr(sys.stdin, termios.TCSAFLUSH, oldattr)
 
-    def read_key():
+    def read_key() -> bytes:
         """
         Waits for a key to be pressed and returns it.
 
@@ -176,7 +177,7 @@ def get_cursor_pos() -> tuple[int, int]:
         return (int(row) - 1, int(col) - 1)
 
 
-def set_cursor_pos(row=0, col=0):
+def set_cursor_pos(row=0, col=0) -> None:
     """
     Sets the cursor to the given row and column. Positions are 0-based.
     """

--- a/zmk/util.py
+++ b/zmk/util.py
@@ -5,9 +5,10 @@ General utilities.
 import functools
 import operator
 import os
+from collections.abc import Iterable
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterable, Optional, TypeVar
+from typing import TypeVar
 
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -41,7 +42,7 @@ def set_directory(path: Path):
 
 
 @contextmanager
-def spinner(message: str, console: Optional[Console] = None, transient: bool = True):
+def spinner(message: str, console: Console | None = None, transient: bool = True):
     """Context manager which displays a loading spinner for its duration"""
     with Progress(
         SpinnerColumn(),

--- a/zmk/util.py
+++ b/zmk/util.py
@@ -5,7 +5,7 @@ General utilities.
 import functools
 import operator
 import os
-from collections.abc import Iterable
+from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TypeVar
@@ -30,7 +30,7 @@ def splice(text: str, index: int, count: int = 0, insert_text: str = ""):
 
 
 @contextmanager
-def set_directory(path: Path):
+def set_directory(path: Path) -> Generator[None, None, None]:
     """Context manager to temporarily change the working directory"""
     original = Path().absolute()
 

--- a/zmk/yaml.py
+++ b/zmk/yaml.py
@@ -4,7 +4,7 @@ YAML parser/printer which preserves any comments before the document.
 
 from io import UnsupportedOperation
 from pathlib import Path
-from typing import IO
+from typing import IO, Optional
 
 import ruamel.yaml
 
@@ -18,7 +18,10 @@ class YAML(ruamel.yaml.YAML):
     readable or seekable, a leading comment will be overwritten.
     """
 
-    def dump(self, data, stream: Path | IO = None, *, transform=None):
+    def dump(self, data, stream: Optional[Path | IO] = None, *, transform=None):
+        if stream is None:
+            raise TypeError("Dumping from a context manager is not supported.")
+
         if isinstance(stream, Path):
             with stream.open("a+", encoding="utf-8") as f:
                 f.seek(0)

--- a/zmk/yaml.py
+++ b/zmk/yaml.py
@@ -4,7 +4,7 @@ YAML parser/printer which preserves any comments before the document.
 
 from io import UnsupportedOperation
 from pathlib import Path
-from typing import IO
+from typing import IO, Any
 
 import ruamel.yaml
 
@@ -18,7 +18,7 @@ class YAML(ruamel.yaml.YAML):
     readable or seekable, a leading comment will be overwritten.
     """
 
-    def dump(self, data, stream: Path | IO | None = None, *, transform=None):
+    def dump(self, data, stream: Path | IO | None = None, *, transform=None) -> None:
         if stream is None:
             raise TypeError("Dumping from a context manager is not supported.")
 
@@ -62,6 +62,6 @@ def _seek_to_document_start(stream: IO):
             return
 
 
-def read_yaml(path: Path):
+def read_yaml(path: Path) -> Any:
     """Parse a YAML file"""
     return YAML().load(path)

--- a/zmk/yaml.py
+++ b/zmk/yaml.py
@@ -4,7 +4,7 @@ YAML parser/printer which preserves any comments before the document.
 
 from io import UnsupportedOperation
 from pathlib import Path
-from typing import IO, Optional
+from typing import IO
 
 import ruamel.yaml
 
@@ -18,7 +18,7 @@ class YAML(ruamel.yaml.YAML):
     readable or seekable, a leading comment will be overwritten.
     """
 
-    def dump(self, data, stream: Optional[Path | IO] = None, *, transform=None):
+    def dump(self, data, stream: Path | IO | None = None, *, transform=None):
         if stream is None:
             raise TypeError("Dumping from a context manager is not supported.")
 


### PR DESCRIPTION
Added a GitHub workflow to run pre-commit, pylint, and pyright.

pylint and pyright are not included as pre-commit checks, because they need to analyze the project as a whole, not just the changed files, and they do not work correctly in an isolated environment without having access to dependencies.

Adjusted the pylint configuration to ignore diagnostics that are either not useful or duplicate those reported by pyright.

Fixed all type errors reported by pyright.

Added VS Code extension recommendations for all the formatting and linting tools, and enabled type checking in VS Code.

Fixes #3 