### PR TITLE
New keyboard template fixes

### DIFF
--- a/zmk/templates/board/nrf52840/split/${id}.conf
+++ b/zmk/templates/board/nrf52840/split/${id}.conf
@@ -1,1 +1,1 @@
-<%inherit file="common/default.conf" />
+<%inherit file="/common/default.conf" />

--- a/zmk/templates/board/nrf52840/split/${id}.dtsi
+++ b/zmk/templates/board/nrf52840/split/${id}.dtsi
@@ -1,4 +1,4 @@
-<%inherit file="common/board.dts" />
+<%inherit file="/common/board.dts" />
 <%block name="system_includes">
 #include <nordic/nrf52840_qiaa.dtsi>
 </%block>
@@ -15,12 +15,12 @@
     };
 </%block>
 <%block name="kscan">
-<%include file="common/kscan_split_common.dtsi" />
+<%include file="/common/kscan_split_common.dtsi" />
 </%block>
 <%block name="matrix_transform">
-<%include file="common/matrix_transform_split.dtsi" />
+<%include file="/common/matrix_transform_split.dtsi" />
 </%block>
 <%block name="nodes">
-<%include file="board/nrf52840/common_inner.dtsi" />
+<%include file="/board/nrf52840/common_inner.dtsi" />
 </%block>
-<%include file="board/nrf52840/common_outer.dtsi" />
+<%include file="/board/nrf52840/common_outer.dtsi" />

--- a/zmk/templates/board/nrf52840/split/${id}.keymap
+++ b/zmk/templates/board/nrf52840/split/${id}.keymap
@@ -1,1 +1,1 @@
-<%inherit file="common/keymap_split.dtsi" />
+<%inherit file="/common/keymap_split.dtsi" />

--- a/zmk/templates/board/nrf52840/split/${id}.yaml
+++ b/zmk/templates/board/nrf52840/split/${id}.yaml
@@ -1,1 +1,1 @@
-<%inherit file="board/nrf52840/board.yaml" />
+<%inherit file="/board/nrf52840/board.yaml" />

--- a/zmk/templates/board/nrf52840/split/${id}.zmk.yml
+++ b/zmk/templates/board/nrf52840/split/${id}.zmk.yml
@@ -1,4 +1,4 @@
-<%inherit file="common/hardware.zmk.yml" />
+<%inherit file="/common/hardware.zmk.yml" />
 outputs:
   - usb
   - ble

--- a/zmk/templates/board/nrf52840/split/${id}_left-pinctrl.dtsi
+++ b/zmk/templates/board/nrf52840/split/${id}_left-pinctrl.dtsi
@@ -1,1 +1,1 @@
-<%inherit file="board/nrf52840/pinctrl.dtsi" />
+<%inherit file="/board/nrf52840/pinctrl.dtsi" />

--- a/zmk/templates/board/nrf52840/split/${id}_left.dts
+++ b/zmk/templates/board/nrf52840/split/${id}_left.dts
@@ -1,1 +1,1 @@
-<%inherit file="common/board_left.dts" />
+<%inherit file="/common/board_left.dts" />

--- a/zmk/templates/board/nrf52840/split/${id}_left_defconfig
+++ b/zmk/templates/board/nrf52840/split/${id}_left_defconfig
@@ -1,1 +1,1 @@
-<%inherit file="board/nrf52840/board_defconfig" />
+<%inherit file="/board/nrf52840/board_defconfig" />

--- a/zmk/templates/board/nrf52840/split/${id}_right-pinctrl.dtsi
+++ b/zmk/templates/board/nrf52840/split/${id}_right-pinctrl.dtsi
@@ -1,1 +1,1 @@
-<%inherit file="board/nrf52840/pinctrl.dtsi" />
+<%inherit file="/board/nrf52840/pinctrl.dtsi" />

--- a/zmk/templates/board/nrf52840/split/${id}_right.dts
+++ b/zmk/templates/board/nrf52840/split/${id}_right.dts
@@ -1,1 +1,1 @@
-<%inherit file="common/board_right.dts" />
+<%inherit file="/common/board_right.dts" />

--- a/zmk/templates/board/nrf52840/split/${id}_right_defconfig
+++ b/zmk/templates/board/nrf52840/split/${id}_right_defconfig
@@ -1,1 +1,1 @@
-<%inherit file="board/nrf52840/board_defconfig" />
+<%inherit file="/board/nrf52840/board_defconfig" />

--- a/zmk/templates/board/nrf52840/split/Kconfig
+++ b/zmk/templates/board/nrf52840/split/Kconfig
@@ -1,3 +1,3 @@
-<%inherit file="board/nrf52840/Kconfig" />
+<%inherit file="/board/nrf52840/Kconfig" />
 
 <%def name="guard()">BOARD_${id.upper()}_LEFT || BOARD_${id.upper()}_RIGHT</%def>

--- a/zmk/templates/board/nrf52840/split/Kconfig.defconfig
+++ b/zmk/templates/board/nrf52840/split/Kconfig.defconfig
@@ -1,4 +1,4 @@
-<%inherit file="board/nrf52840/Kconfig.defconfig" />
+<%inherit file="/board/nrf52840/Kconfig.defconfig" />
 
 <%def name="guard()">BOARD_${id.upper()}_LEFT || BOARD_${id.upper()}_RIGHT</%def>
 

--- a/zmk/templates/board/nrf52840/split/board.cmake
+++ b/zmk/templates/board/nrf52840/split/board.cmake
@@ -1,1 +1,1 @@
-<%inherit file="board/nrf52840/board.cmake" />
+<%inherit file="/board/nrf52840/board.cmake" />

--- a/zmk/templates/board/nrf52840/unibody/${id}-pinctrl.dtsi
+++ b/zmk/templates/board/nrf52840/unibody/${id}-pinctrl.dtsi
@@ -1,1 +1,1 @@
-<%inherit file="board/nrf52840/pinctrl.dtsi" />
+<%inherit file="/board/nrf52840/pinctrl.dtsi" />

--- a/zmk/templates/board/nrf52840/unibody/${id}.conf
+++ b/zmk/templates/board/nrf52840/unibody/${id}.conf
@@ -1,1 +1,1 @@
-<%inherit file="common/default.conf" />
+<%inherit file="/common/default.conf" />

--- a/zmk/templates/board/nrf52840/unibody/${id}.dts
+++ b/zmk/templates/board/nrf52840/unibody/${id}.dts
@@ -1,4 +1,4 @@
-<%inherit file="common/board.dts" />
+<%inherit file="/common/board.dts" />
 <%block name="system_includes">
 #include <nordic/nrf52840_qiaa.dtsi>
 </%block>
@@ -19,6 +19,6 @@
     };
 </%block>
 <%block name="nodes">
-<%include file="board/nrf52840/common_inner.dtsi" />
+<%include file="/board/nrf52840/common_inner.dtsi" />
 </%block>
-<%include file="board/nrf52840/common_outer.dtsi" />
+<%include file="/board/nrf52840/common_outer.dtsi" />

--- a/zmk/templates/board/nrf52840/unibody/${id}.keymap
+++ b/zmk/templates/board/nrf52840/unibody/${id}.keymap
@@ -1,1 +1,1 @@
-<%inherit file="common/keymap.dtsi" />
+<%inherit file="/common/keymap.dtsi" />

--- a/zmk/templates/board/nrf52840/unibody/${id}.yaml
+++ b/zmk/templates/board/nrf52840/unibody/${id}.yaml
@@ -1,1 +1,1 @@
-<%inherit file="board/nrf52840/board.yaml" />
+<%inherit file="/board/nrf52840/board.yaml" />

--- a/zmk/templates/board/nrf52840/unibody/${id}.zmk.yml
+++ b/zmk/templates/board/nrf52840/unibody/${id}.zmk.yml
@@ -1,4 +1,4 @@
-<%inherit file="common/hardware.zmk.yml" />
+<%inherit file="/common/hardware.zmk.yml" />
 outputs:
   - usb
   - ble

--- a/zmk/templates/board/nrf52840/unibody/${id}_defconfig
+++ b/zmk/templates/board/nrf52840/unibody/${id}_defconfig
@@ -1,1 +1,1 @@
-<%inherit file="board/nrf52840/board_defconfig" />
+<%inherit file="/board/nrf52840/board_defconfig" />

--- a/zmk/templates/board/nrf52840/unibody/Kconfig
+++ b/zmk/templates/board/nrf52840/unibody/Kconfig
@@ -1,3 +1,3 @@
-<%inherit file="board/nrf52840/Kconfig" />
+<%inherit file="/board/nrf52840/Kconfig" />
 
 <%def name="guard()">BOARD_${id.upper()}</%def>

--- a/zmk/templates/board/nrf52840/unibody/Kconfig.defconfig
+++ b/zmk/templates/board/nrf52840/unibody/Kconfig.defconfig
@@ -1,4 +1,4 @@
-<%inherit file="board/nrf52840/Kconfig.defconfig" />
+<%inherit file="/board/nrf52840/Kconfig.defconfig" />
 
 <%def name="guard()">BOARD_${id.upper()}</%def>
 

--- a/zmk/templates/board/nrf52840/unibody/board.cmake
+++ b/zmk/templates/board/nrf52840/unibody/board.cmake
@@ -1,1 +1,1 @@
-<%inherit file="board/nrf52840/board.cmake" />
+<%inherit file="/board/nrf52840/board.cmake" />

--- a/zmk/templates/board/other/split/${id}.conf
+++ b/zmk/templates/board/other/split/${id}.conf
@@ -1,1 +1,1 @@
-<%inherit file="common/default.conf" />
+<%inherit file="/common/default.conf" />

--- a/zmk/templates/board/other/split/${id}.dtsi
+++ b/zmk/templates/board/other/split/${id}.dtsi
@@ -1,4 +1,4 @@
-<%inherit file="common/board_split.dtsi" />\
+<%inherit file="/common/board_split.dtsi" />\
 <%block name="includes">
 #include "${id}-pinctrl.dtsi"
 

--- a/zmk/templates/board/other/split/${id}.keymap
+++ b/zmk/templates/board/other/split/${id}.keymap
@@ -1,1 +1,1 @@
-<%inherit file="common/keymap_split.dtsi" />
+<%inherit file="/common/keymap_split.dtsi" />

--- a/zmk/templates/board/other/split/${id}.yaml
+++ b/zmk/templates/board/other/split/${id}.yaml
@@ -1,1 +1,1 @@
-<%inherit file="board/other/board.yaml" />
+<%inherit file="/board/other/board.yaml" />

--- a/zmk/templates/board/other/split/${id}.zmk.yml
+++ b/zmk/templates/board/other/split/${id}.zmk.yml
@@ -1,4 +1,4 @@
-<%inherit file="common/hardware.zmk.yml" />
+<%inherit file="/common/hardware.zmk.yml" />
 outputs:
   - usb
 #   - ble

--- a/zmk/templates/board/other/split/${id}_left-pinctrl.dtsi
+++ b/zmk/templates/board/other/split/${id}_left-pinctrl.dtsi
@@ -1,1 +1,1 @@
-<%inherit file="board/other/pinctrl.dtsi" />
+<%inherit file="/board/other/pinctrl.dtsi" />

--- a/zmk/templates/board/other/split/${id}_left.dts
+++ b/zmk/templates/board/other/split/${id}_left.dts
@@ -1,1 +1,1 @@
-<%inherit file="common/board_left.dts" />
+<%inherit file="/common/board_left.dts" />

--- a/zmk/templates/board/other/split/${id}_left_defconfig
+++ b/zmk/templates/board/other/split/${id}_left_defconfig
@@ -1,1 +1,1 @@
-<%inherit file="board/other/board_defconfig" />
+<%inherit file="/board/other/board_defconfig" />

--- a/zmk/templates/board/other/split/${id}_right-pinctrl.dtsi
+++ b/zmk/templates/board/other/split/${id}_right-pinctrl.dtsi
@@ -1,1 +1,1 @@
-<%inherit file="board/other/pinctrl.dtsi" />
+<%inherit file="/board/other/pinctrl.dtsi" />

--- a/zmk/templates/board/other/split/${id}_right.dts
+++ b/zmk/templates/board/other/split/${id}_right.dts
@@ -1,1 +1,1 @@
-<%inherit file="common/board_right.dts" />
+<%inherit file="/common/board_right.dts" />

--- a/zmk/templates/board/other/split/${id}_right_defconfig
+++ b/zmk/templates/board/other/split/${id}_right_defconfig
@@ -1,1 +1,1 @@
-<%inherit file="board/other/board_defconfig" />
+<%inherit file="/board/other/board_defconfig" />

--- a/zmk/templates/board/other/split/Kconfig
+++ b/zmk/templates/board/other/split/Kconfig
@@ -1,3 +1,3 @@
-<%inherit file="board/other/Kconfig" />
+<%inherit file="/board/other/Kconfig" />
 
 <%def name="guard()">BOARD_${id.upper()}_LEFT || BOARD_${id.upper()}_RIGHT</%def>

--- a/zmk/templates/board/other/split/Kconfig.defconfig
+++ b/zmk/templates/board/other/split/Kconfig.defconfig
@@ -1,4 +1,4 @@
-<%inherit file="board/other/Kconfig.defconfig" />
+<%inherit file="/board/other/Kconfig.defconfig" />
 
 <%def name="guard()">BOARD_${id.upper()}_LEFT || BOARD_${id.upper()}_RIGHT</%def>
 

--- a/zmk/templates/board/other/split/board.cmake
+++ b/zmk/templates/board/other/split/board.cmake
@@ -1,1 +1,1 @@
-<%inherit file="board/other/board.cmake" />
+<%inherit file="/board/other/board.cmake" />

--- a/zmk/templates/board/other/unibody/${id}-pinctrl.dtsi
+++ b/zmk/templates/board/other/unibody/${id}-pinctrl.dtsi
@@ -1,1 +1,1 @@
-<%inherit file="board/other/pinctrl.dtsi" />
+<%inherit file="/board/other/pinctrl.dtsi" />

--- a/zmk/templates/board/other/unibody/${id}.conf
+++ b/zmk/templates/board/other/unibody/${id}.conf
@@ -1,1 +1,1 @@
-<%inherit file="common/default.conf" />
+<%inherit file="/common/default.conf" />

--- a/zmk/templates/board/other/unibody/${id}.dts
+++ b/zmk/templates/board/other/unibody/${id}.dts
@@ -1,4 +1,4 @@
-<%inherit file="common/board.dts" />
+<%inherit file="/common/board.dts" />
 <%block name="includes">
 #include "${id}-pinctrl.dtsi"
 

--- a/zmk/templates/board/other/unibody/${id}.keymap
+++ b/zmk/templates/board/other/unibody/${id}.keymap
@@ -1,1 +1,1 @@
-<%inherit file="common/keymap.dtsi" />
+<%inherit file="/common/keymap.dtsi" />

--- a/zmk/templates/board/other/unibody/${id}.yaml
+++ b/zmk/templates/board/other/unibody/${id}.yaml
@@ -1,1 +1,1 @@
-<%inherit file="board/other/board.yaml" />
+<%inherit file="/board/other/board.yaml" />

--- a/zmk/templates/board/other/unibody/${id}.zmk.yml
+++ b/zmk/templates/board/other/unibody/${id}.zmk.yml
@@ -1,4 +1,4 @@
-<%inherit file="common/hardware.zmk.yml" />
+<%inherit file="/common/hardware.zmk.yml" />
 outputs:
   - usb
 #   - ble

--- a/zmk/templates/board/other/unibody/${id}_defconfig
+++ b/zmk/templates/board/other/unibody/${id}_defconfig
@@ -1,1 +1,1 @@
-<%inherit file="board/other/board_defconfig" />
+<%inherit file="/board/other/board_defconfig" />

--- a/zmk/templates/board/other/unibody/Kconfig
+++ b/zmk/templates/board/other/unibody/Kconfig
@@ -1,3 +1,3 @@
-<%inherit file="board/other/Kconfig" />
+<%inherit file="/board/other/Kconfig" />
 
 <%def name="guard()">BOARD_${id.upper()}</%def>

--- a/zmk/templates/board/other/unibody/Kconfig.defconfig
+++ b/zmk/templates/board/other/unibody/Kconfig.defconfig
@@ -1,4 +1,4 @@
-<%inherit file="board/other/Kconfig.defconfig" />
+<%inherit file="/board/other/Kconfig.defconfig" />
 
 <%def name="guard()">BOARD_${id.upper()}</%def>
 

--- a/zmk/templates/board/other/unibody/board.cmake
+++ b/zmk/templates/board/other/unibody/board.cmake
@@ -1,1 +1,1 @@
-<%inherit file="board/other/board.cmake" />
+<%inherit file="/board/other/board.cmake" />

--- a/zmk/templates/common/kscan.dtsi
+++ b/zmk/templates/common/kscan.dtsi
@@ -18,7 +18,7 @@
             ;
 
         row-gpios
-            = </* &gpio0 0 */ (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , </* &gpio0 0 */ (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            = </* ${node} 0 */ (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , </* ${node} 0 */ (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
     };

--- a/zmk/templates/shield/split/${id}.conf
+++ b/zmk/templates/shield/split/${id}.conf
@@ -1,1 +1,1 @@
-<%inherit file="common/default.conf" />
+<%inherit file="/common/default.conf" />

--- a/zmk/templates/shield/split/${id}.dtsi
+++ b/zmk/templates/shield/split/${id}.dtsi
@@ -1,7 +1,7 @@
-<%inherit file="common/shield.overlay" />
+<%inherit file="/common/shield.overlay" />
 <%block name="kscan">
-<%include file="common/kscan_split_common.dtsi" args="node = '&pro_micro'" />
+<%include file="/common/kscan_split_common.dtsi" args="node = '&pro_micro'" />
 </%block>
 <%block name="matrix_transform">
-<%include file="common/matrix_transform_split.dtsi" />
+<%include file="/common/matrix_transform_split.dtsi" />
 </%block>

--- a/zmk/templates/shield/split/${id}.keymap
+++ b/zmk/templates/shield/split/${id}.keymap
@@ -1,1 +1,1 @@
-<%inherit file="common/keymap_split.dtsi" />
+<%inherit file="/common/keymap_split.dtsi" />

--- a/zmk/templates/shield/split/${id}.zmk.yml
+++ b/zmk/templates/shield/split/${id}.zmk.yml
@@ -1,4 +1,4 @@
-<%inherit file="common/hardware.zmk.yml" />
+<%inherit file="/common/hardware.zmk.yml" />
 # Set this to the interconnect the shield uses.
 # Run "zmk keyboard list --type interconnect" to get the possible values.
 requires:

--- a/zmk/templates/shield/split/${id}_left.overlay
+++ b/zmk/templates/shield/split/${id}_left.overlay
@@ -1,1 +1,1 @@
-<%inherit file="common/shield_left.overlay" />
+<%inherit file="/common/shield_left.overlay" />

--- a/zmk/templates/shield/split/${id}_right.overlay
+++ b/zmk/templates/shield/split/${id}_right.overlay
@@ -1,1 +1,1 @@
-<%inherit file="common/shield_right.overlay" />
+<%inherit file="/common/shield_right.overlay" />

--- a/zmk/templates/shield/unibody/${id}.conf
+++ b/zmk/templates/shield/unibody/${id}.conf
@@ -1,1 +1,1 @@
-<%inherit file="common/default.conf" />
+<%inherit file="/common/default.conf" />

--- a/zmk/templates/shield/unibody/${id}.keymap
+++ b/zmk/templates/shield/unibody/${id}.keymap
@@ -1,1 +1,1 @@
-<%inherit file="common/keymap.dtsi" />
+<%inherit file="/common/keymap.dtsi" />

--- a/zmk/templates/shield/unibody/${id}.overlay
+++ b/zmk/templates/shield/unibody/${id}.overlay
@@ -1,4 +1,4 @@
-<%inherit file="common/shield.overlay" />
+<%inherit file="/common/shield.overlay" />
 <%block name="kscan">
-<%include file="common/kscan.dtsi" args="node = '&pro_micro'" />
+<%include file="/common/kscan.dtsi" args="node = '&pro_micro'" />
 </%block>

--- a/zmk/templates/shield/unibody/${id}.zmk.yml
+++ b/zmk/templates/shield/unibody/${id}.zmk.yml
@@ -1,4 +1,4 @@
-<%inherit file="common/hardware.zmk.yml" />
+<%inherit file="/common/hardware.zmk.yml" />
 # Set this to the interconnect the shield uses.
 # Run "zmk keyboard list --type interconnect" to get the possible values.
 requires:


### PR DESCRIPTION
Fixed an issue with template generation failing on Linux (and hopefully macOS). 

Also fixed an incorrect node name in the unibody kscan template.