### PR TITLE
Fix Python 3.10 errors

### DIFF
--- a/zmk/build.py
+++ b/zmk/build.py
@@ -5,7 +5,7 @@ Build matrix processing.
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Self, TypeVar, cast, overload
+from typing import Any, TypeVar, cast, overload
 
 import dacite
 
@@ -57,7 +57,7 @@ class BuildMatrix:
     _data: dict[str, Any] | None
 
     @classmethod
-    def from_repo(cls, repo: Repo) -> Self:
+    def from_repo(cls, repo: Repo) -> "BuildMatrix":
         """Get the build matrix for a repo"""
         return cls(repo.build_matrix_path)
 

--- a/zmk/hardware.py
+++ b/zmk/hardware.py
@@ -6,7 +6,7 @@ from collections.abc import Generator, Iterable
 from dataclasses import dataclass, field
 from functools import reduce
 from pathlib import Path
-from typing import Any, Literal, Self, TypeAlias, TypeGuard
+from typing import Any, Literal, Type, TypeAlias, TypeGuard, TypeVar
 
 import dacite
 
@@ -21,6 +21,9 @@ Output: TypeAlias = Literal["usb", "ble"]
 
 # TODO: dict should match { id: str, features: list[Feature] }
 Variant: TypeAlias = str | dict[str, str]
+
+# TODO: replace with typing.Self once minimum Python version is >= 3.11
+_Self = TypeVar("_Self", bound="Hardware")
 
 
 @dataclass
@@ -47,7 +50,7 @@ class Hardware:
         return f"{self.id}  [dim]{self.name}"
 
     @classmethod
-    def from_dict(cls, data) -> Self:
+    def from_dict(cls: "Type[_Self]", data) -> _Self:
         """Read a hardware description from a dict"""
         return dacite.from_dict(cls, data)
 


### PR DESCRIPTION
typing.Self requires Python 3.11. Replaced it with the class name for types that aren't subclassed or a TypeVar for types that are.

The type annotation on Hardware.from_dict() must be given as a string, or pyupgrade will convert it to type[_Self], which breaks because Hardware has a member named "type" (which cannot be renamed since it must match the name of the YAML files the class represents).

Fixes #9