### PR TITLE
fix(templates): Escape <& in templates

### DIFF
--- a/zmk/templates/board/nrf52840/common_inner.dtsi
+++ b/zmk/templates/board/nrf52840/common_inner.dtsi
@@ -23,7 +23,7 @@
 
     // vbatt: vbatt {
     //     compatible = "voltage-divider";
-    //     io-channels = <&adc 2>;
+    //     io-channels = <${'&adc 2'}>;
     //     output-ohms = <2000000>;
     //     full-ohms = <(2000000 + 806000)>;
     // };

--- a/zmk/templates/board/nrf52840/common_outer.dtsi
+++ b/zmk/templates/board/nrf52840/common_outer.dtsi
@@ -17,8 +17,8 @@
 &uart0 {
     compatible = "nordic,nrf-uarte";
     current-speed = <115200>;
-    pinctrl-0 = <&uart0_default>;
-    pinctrl-1 = <&uart0_sleep>;
+    pinctrl-0 = <${'&uart0_default'}>;
+    pinctrl-1 = <${'&uart0_sleep'}>;
     pinctrl-names = "default", "sleep";
 };
 

--- a/zmk/templates/common/layouts.dtsi
+++ b/zmk/templates/common/layouts.dtsi
@@ -7,17 +7,17 @@
     default_layout: default_layout {
         compatible = "zmk,physical-layout";
         display-name = "Default Layout";
-        transform = <&default_transform>;
-        kscan = <&kscan>;
+        transform = <${'&default_transform'}>;
+        kscan = <${'&kscan'}>;
 
         // Edit this to define the positions and sizes of the keys, or remove it
         // if your keyboard will not support ZMK Studio.
         // https://zmk.dev/docs/development/hardware-integration/physical-layouts#optional-keys-property
         keys  //                     w   h    x    y     rot    rx    ry
-            = <&key_physical_attrs 100 100    0    0       0     0     0>
-            , <&key_physical_attrs 100 100  100    0       0     0     0>
-            , <&key_physical_attrs 100 100    0  100       0     0     0>
-            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            = <${'&key_physical_attrs'} 100 100    0    0       0     0     0>
+            , <${'&key_physical_attrs'} 100 100  100    0       0     0     0>
+            , <${'&key_physical_attrs'} 100 100    0  100       0     0     0>
+            , <${'&key_physical_attrs'} 100 100  100  100       0     0     0>
             ;
     };
 };


### PR DESCRIPTION
Mako has an undocumented behavior (likely a bug) where `<&` gets turned into just `&`. This is a fairly common sequence in Devicetree, so there were a few places in the templates affected by this.

This changes all instances of `<&node>` to `<${'&node'}>` as a workaround.