### PR TITLE
fix: replaces typer.launch with webbrowser.open

### DIFF
--- a/zmk/commands/download.py
+++ b/zmk/commands/download.py
@@ -2,6 +2,8 @@
 "zmk download" command.
 """
 
+import webbrowser
+
 import typer
 
 from ..config import get_config
@@ -16,7 +18,7 @@ def download(ctx: typer.Context) -> None:
 
     actions_url = _get_actions_url(repo)
 
-    typer.launch(actions_url)
+    webbrowser.open(actions_url)
 
 
 def _get_actions_url(repo: Repo):

--- a/zmk/commands/init.py
+++ b/zmk/commands/init.py
@@ -5,6 +5,7 @@
 import platform
 import shutil
 import subprocess
+import webbrowser
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -115,7 +116,7 @@ def _get_repo_url():
         width=TEXT_WIDTH,
     )
     input()
-    typer.launch(TEMPLATE_URL)
+    webbrowser.open(TEMPLATE_URL)
 
     url = UrlPrompt.ask("Repository URL")
     return url


### PR DESCRIPTION
Per this [comment](https://github.com/zmkfirmware/zmk-cli/issues/23#issuecomment-2743996708) in #23, this replaces `typer.launch` with `webbrowser.open`

I tested it locally with PowerShell and it successfully opened the link.