### PR TITLE
Remove use of shell in subprocess call

### DIFF
--- a/zmk/commands/code.py
+++ b/zmk/commands/code.py
@@ -54,7 +54,7 @@ def code(
     editor = _get_editor(cfg, path.is_dir())
 
     cmd = shlex.split(editor) + [path]
-    subprocess.call(cmd, shell=True)
+    subprocess.call(cmd)
 
 
 def _get_file(repo: Repo, keyboard: str | None, open_conf: bool):


### PR DESCRIPTION
- Resolves issue #27
- use of shell=True requires a string, not a list, and also has some security considerations: https://docs.python.org/3.10/library/subprocess.html#security-considerations

This fixes it for myself, but there may have been a good reason for using `shell=True`, so understandable if this simple "fix" isn't suitable.