### PR TITLE
Use full path to shell

### DIFF
--- a/zmk/commands/cd.py
+++ b/zmk/commands/cd.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+import shutil
 
 import shellingham
 import typer
@@ -39,6 +40,7 @@ def cd(ctx: typer.Context) -> None:
 
     try:
         _, shell = shellingham.detect_shell()
+        shell = shutil.which(shell) or _default_shell()
     except shellingham.ShellDetectionFailure:
         shell = _default_shell()
 


### PR DESCRIPTION
- Resolves #26
- execl requires the full path as the first argument, not just the shell name returned by shellingham