### PR TITLE
fix: Update build matrix when adding board only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# VS Code settings
+.vscode/launch.json

--- a/zmk/commands/keyboard/add.py
+++ b/zmk/commands/keyboard/add.py
@@ -158,7 +158,12 @@ def _get_build_items(keyboard: Keyboard, controller: Board | None):
         case _:
             raise ValueError("Unexpected keyboard/controller combination")
 
-    return [BuildItem(board=b, shield=s) for b, s in itertools.product(boards, shields)]
+    if shields:
+        return [
+            BuildItem(board=b, shield=s) for b, s in itertools.product(boards, shields)
+        ]
+
+    return [BuildItem(board=b) for b in boards]
 
 
 def _add_keyboard(repo: Repo, keyboard: Keyboard, controller: Board | None):


### PR DESCRIPTION

This fixes an issue where "zmk keyboard add" did not update the build matrix when adding a keyboard that used only boards and no shields.

Fixes https://github.com/zmkfirmware/zmk-cli/issues/18