### PR TITLE
fix(templates): Add siblings to split shield

### DIFF
--- a/zmk/templates/shield/split/${id}.zmk.yml
+++ b/zmk/templates/shield/split/${id}.zmk.yml
@@ -3,3 +3,7 @@
 requires:
   - ${interconnect}
 % endif
+
+siblings:
+  - ${id}_left
+  - ${id}_right


### PR DESCRIPTION
Updated the .zmk.yml file for a split shield to include the siblings list.

Fixes #17