### PR TITLE
fix: Disable ConfigParser interpolation

### DIFF
--- a/zmk/config.py
+++ b/zmk/config.py
@@ -35,7 +35,7 @@ class Config:
         self.force_home = force_home
 
         self._overrides: defaultdict[str, dict[str, str]] = defaultdict(dict)
-        self._parser = ConfigParser()
+        self._parser = ConfigParser(interpolation=None)
         self._parser.read(self.path, encoding="utf-8")
 
     def write(self) -> None:


### PR DESCRIPTION
By default, ConfigParser supports variable interpolation using "%(name)" syntax, but this means that all percent signs in values need to be escaped. I can't think of any good uses for this behavior in ZMK CLI, so this commit disables interpolation.

Fixes #40